### PR TITLE
Fix bug in year preview after start-over clicked

### DIFF
--- a/src/static/js/modules/preview.js
+++ b/src/static/js/modules/preview.js
@@ -163,12 +163,12 @@ var PDP = (function ( pdp ) {
         years = $.map( $('#as_of_year option'), function( year ) {
           return year.value;
         });
-
-    // If there's a year param in the URL, grab any valid years from it.
+      
+    // If there's a year param in the query, grab any valid years from it.
     if ( typeof pdp.query.params.as_of_year !== 'undefined' && !_.isEmpty(pdp.query.params.as_of_year.values) ) {
-      years = _.filter( _.clone( pdp.query.params.as_of_year.values ).sort(), function( year ) {
-        return years.indexOf( year ) > -1;
-      });
+      years = _.filter( _.clone( pdp.query.params.as_of_year.values ), function( year ) {
+          return years.indexOf( String(year) ) > -1;
+      }); 
     }
 
     switch( $('#suggested').val() ) {
@@ -189,7 +189,8 @@ var PDP = (function ( pdp ) {
     }
 
     if ( years.length > 1 ) {
-
+          
+      years = years.sort()
       // Are the selected years consecutive?
       areConsecutive = _.every( years, function( val, i, arr ){
         if ( i > 0 ) {

--- a/src/static/js/templates/template.js
+++ b/src/static/js/templates/template.js
@@ -12,7 +12,7 @@ __p += '<ul class="fields location-set location-set-' +
 ((__t = ( num )) == null ? '' : __t) +
 '">\n\n  ';
  if (num === 1) { ;
-__p += '\n    <div class="msg msa-warning hidden">\n      Metro area filters are not available for the combination of years you selected.\n      Due to the recent changes in MSA definitions, we\'ve disabled metro area filters when you select 2014 and another year. To learn more, see <a href="#msa-note" id="highlight-msa-note">note above</a>.\n    </div>\n  ';
+__p += '\n    <div class="msg msa-warning hidden">\n      Due to the recent changes in MSA definitions, we\'ve disabled metro area filters when you select 2014 and another year. To learn more, see <a href="#msa-note" id="highlight-msa-note">note above</a>.\n    </div>\n  ';
  } ;
 __p += '\n\n  <!-- filter field -->\n  <li class="field state_code state_code-' +
 ((__t = ( num )) == null ? '' : __t) +


### PR DESCRIPTION
Filter was searching for the wrong type. Also moved sort down to the
rangeify section.